### PR TITLE
Only convert hex and legacy codes in message format

### DIFF
--- a/src/main/java/sh/charlie/chitchat/listener/ChatListener.java
+++ b/src/main/java/sh/charlie/chitchat/listener/ChatListener.java
@@ -65,12 +65,13 @@ public class ChatListener implements Listener {
             }
 
             MiniMessage miniMessage = plugin.getMiniMessage();
-            String chatColor = plugin.getConfig().getString("formats." + format + ".chat_color", "");
+            String chatColor = MessageHandler.replaceLegacyCodes(plugin.getConfig()
+                    .getString("formats." + format + ".chat_color", ""));
 
-            miniStr = new StringBuilder(miniStr.toString().replace("%message%", chatColor + plugin.getMiniMessage().serialize(e.message())));
-
-            String finalReplacement = MessageHandler.replaceLegacyCodes(miniStr.toString());
-            Component component = miniMessage.deserialize(plugin.convertHex(finalReplacement));
+            String legacyReplaced = MessageHandler.replaceLegacyCodes(miniStr.toString());
+            String finalReplaced = legacyReplaced.replace("%message%",
+                    chatColor + plugin.getMiniMessage().serialize(e.message()));
+            Component component = miniMessage.deserialize(finalReplaced);
 
             if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
                 component = MessageHandler.replacePlaceholderApiPlaceholders(player, component);

--- a/src/main/java/sh/charlie/chitchat/util/MessageHandler.java
+++ b/src/main/java/sh/charlie/chitchat/util/MessageHandler.java
@@ -280,8 +280,6 @@ public class MessageHandler {
      * @return
      */
     public static Component replacePlaceholderApiPlaceholders(Player player, Component component) {
-
-        final String HEX_PATTERN_STRING = "#(?:[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})";
         Pattern pattern = PlaceholderAPI.getPlaceholderPattern();
 
         TextReplacementConfig replacementConfig = TextReplacementConfig.builder().match(pattern).replacement(((matchResult, builder) -> {


### PR DESCRIPTION
We know that the output of plugin.getMiniMessage().serialize(e.message()) is already in the modern MiniMessage format, so there's no need to convert anything. 

Also, instead of calling plugin#convertHex twice (it's also called in replaceLegacyCodes), we just leave it up to replaceLegacyCodes to do.